### PR TITLE
Add locks to avoid concurrent map writing

### DIFF
--- a/tools/control.go
+++ b/tools/control.go
@@ -23,7 +23,7 @@ type HmsControlData struct {
 }
 
 //Extract simulation variables from the control file...
-func getControlData(hm *HmsModel, file string, wg *sync.WaitGroup) {
+func getControlData(hm *HmsModel, file string, wg *sync.WaitGroup, mu *sync.Mutex) {
 
 	defer wg.Done()
 
@@ -34,7 +34,9 @@ func getControlData(hm *HmsModel, file string, wg *sync.WaitGroup) {
 	f, err := hm.FileStore.GetObject(filePath)
 	if err != nil {
 		controlData.Notes += fmt.Sprintf("%s failed to process. ", file)
+		mu.Lock()
 		hm.Metadata.ControlMetadata[file] = controlData
+		mu.Unlock()
 		return
 	}
 
@@ -77,5 +79,8 @@ func getControlData(hm *HmsModel, file string, wg *sync.WaitGroup) {
 		}
 	}
 	controlData.Hash = fmt.Sprintf("%x", hasher.Sum(nil))
+
+	mu.Lock()
 	hm.Metadata.ControlMetadata[file] = controlData
+	mu.Unlock()
 }

--- a/tools/forcing.go
+++ b/tools/forcing.go
@@ -27,7 +27,7 @@ type HmsForcingData struct {
 }
 
 //Extract meteorological variables from the forcing files...
-func getForcingData(hm *HmsModel, file string, wg *sync.WaitGroup) {
+func getForcingData(hm *HmsModel, file string, wg *sync.WaitGroup, mu *sync.Mutex) {
 
 	defer wg.Done()
 
@@ -38,7 +38,9 @@ func getForcingData(hm *HmsModel, file string, wg *sync.WaitGroup) {
 	f, err := hm.FileStore.GetObject(filePath)
 	if err != nil {
 		forcingData.Notes += fmt.Sprintf("%s failed to process. ", file)
+		mu.Lock()
 		hm.Metadata.ForcingMetadata[file] = forcingData
+		mu.Unlock()
 		return
 	}
 
@@ -95,5 +97,8 @@ func getForcingData(hm *HmsModel, file string, wg *sync.WaitGroup) {
 		}
 	}
 	forcingData.Hash = fmt.Sprintf("%x", hasher.Sum(nil))
+
+	mu.Lock()
 	hm.Metadata.ForcingMetadata[file] = forcingData
+	mu.Unlock()
 }

--- a/tools/geom.go
+++ b/tools/geom.go
@@ -61,7 +61,7 @@ func getGridPath(hm *HmsModel) {
 }
 
 //Extract features and their properties from the geometry files...
-func getGeometryData(hm *HmsModel, file string, wg *sync.WaitGroup) {
+func getGeometryData(hm *HmsModel, file string, wg *sync.WaitGroup, mu *sync.Mutex) {
 
 	defer wg.Done()
 
@@ -74,7 +74,9 @@ func getGeometryData(hm *HmsModel, file string, wg *sync.WaitGroup) {
 	f, err := hm.FileStore.GetObject(filePath)
 	if err != nil {
 		geometryData.Notes += fmt.Sprintf("%s failed to process. ", file)
+		mu.Lock()
 		hm.Metadata.GeometryMetadata[file] = geometryData
+		mu.Unlock()
 		return
 	}
 
@@ -167,7 +169,10 @@ out:
 
 	}
 	geometryData.Hash = fmt.Sprintf("%x", hasher.Sum(nil))
+
+	mu.Lock()
 	hm.Metadata.GeometryMetadata[file] = geometryData
+	mu.Unlock()
 }
 
 //Check that the geometry reference files exists, read them into memory, and serialize ...


### PR DESCRIPTION
Different go routines were trying to simultaneously write to the same maps of the model struct causing a runtime error.